### PR TITLE
fix: setup.py Build with cuda if TORCH_CUDA_ARCH_LIST is set

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ def get_extensions():
     extra_compile_args = {"cxx": []}
     define_macros = []
 
-    if torch.cuda.is_available() and CUDA_HOME is not None:
+    if CUDA_HOME is not None and (torch.cuda.is_available() or "TORCH_CUDA_ARCH_LIST" in os.environ):
         print("Compiling with CUDA")
         extension = CUDAExtension
         sources += source_cuda


### PR DESCRIPTION
When cuda is unavailable, the error occurs on the following line.

https://github.com/pytorch/pytorch/blob/a943df045f4d96488ca4679beba23ed05afc9b39/torch/utils/cpp_extension.py#L1773
```python
            if arch not in arch_list:
                arch_list.append(arch)
        arch_list = sorted(arch_list)
        arch_list[-1] += '+PTX'  # ←
```

Setting `TORCH_CUDA_ARCH_LIST` environment variable can prevent this.


```yaml
name: Python Build Wheel

on: [workflow_dispatch]

jobs:
  build:
    runs-on: ${{ matrix.os }}
    strategy:
      matrix:
        os: [ubuntu-20.04, windows-2019]
        python-version: ["3.9", "3.10"]
        config:
          - torch-version: "1.13.1"
            cuda-version: "11.7.1"
            arch_list: "3.7;3.5+PTX;5.3;5.0;5.2+PTX;6.0;6.1+PTX;7.0+PTX;7.5+PTX;8.0;8.6+PTX"
            torch-command: pip install torch==1.13.1+cu117 torchvision==0.14.1+cu117 --extra-index-url https://download.pytorch.org/whl/cu117

          - torch-version: "2.0.0"
            cuda-version: "11.7.1"
            arch_list: "3.7;3.5+PTX;5.3;5.0;5.2+PTX;6.0;6.1+PTX;7.0+PTX;7.5+PTX;8.0;8.6+PTX"
            torch-command: pip install torch==2.0.0+cu117 torchvision==0.15.1+cu117 --index-url https://download.pytorch.org/whl/cu117

          - torch-version: "2.0.0"
            cuda-version: "11.8.0"
            arch_list: "3.7;3.5+PTX;5.3;5.0;5.2+PTX;6.0;6.1+PTX;7.0+PTX;7.5+PTX;8.0;8.6+PTX;8.9+PTX;9.0+PTX"
            torch-command: pip install torch==2.0.0+cu118 torchvision==0.15.1+cu118 --index-url https://download.pytorch.org/whl/cu118

    steps:
      - name: Checkout repository
        uses: actions/checkout@v3

      - name: Set up python
        uses: actions/setup-python@v4
        with:
          python-version: ${{ matrix.python-version }}

      - name: Install dependencies
        run: |
          pip install -U setuptools wheel ninja
          ${{ matrix.config.torch-command }}

      - name: Set up cudatoolkit
        uses: Jimver/cuda-toolkit@v0.2.10
        id: cuda-toolkit
        with:
          cuda: ${{ matrix.config.cuda-version }}

      - run: echo "Installed cuda version is → ${{steps.cuda-toolkit.outputs.cuda}}"
      - run: echo "Cuda install location → ${{steps.cuda-toolkit.outputs.CUDA_PATH}}"

      - name: Build wheel
        env:
          CUDA_HOME: ${{ steps.cuda-toolkit.outputs.CUDA_PATH }}
          TORCH_CUDA_ARCH_LIST: ${{ matrix.config.arch_list }}
        run: |
          python setup.py bdist_wheel

      - name: Upload wheel
        uses: actions/upload-artifact@v3
        with:
          name: ${{ matrix.os }}-py${{ matrix.python-version }}-torch${{ matrix.config.torch-version }}-cu${{ matrix.config.cuda-version }}
          path: dist/*.whl
```

This github action has successfully built the wheel files. see: https://github.com/Bing-su/GroundingDINO/actions/runs/4719244071
Please feel free to use it.