### PR TITLE
use model.device when calling legacy predict

### DIFF
--- a/groundingdino/util/inference.py
+++ b/groundingdino/util/inference.py
@@ -153,7 +153,8 @@ class Model:
             image=processed_image,
             caption=caption,
             box_threshold=box_threshold,
-            text_threshold=text_threshold)
+            text_threshold=text_threshold, 
+            device=self.model.device)
         source_h, source_w, _ = image.shape
         detections = Model.post_process_result(
             source_h=source_h,
@@ -195,7 +196,8 @@ class Model:
             image=processed_image,
             caption=caption,
             box_threshold=box_threshold,
-            text_threshold=text_threshold)
+            text_threshold=text_threshold,
+            device=self.model.device)
         source_h, source_w, _ = image.shape
         detections = Model.post_process_result(
             source_h=source_h,


### PR DESCRIPTION
Since legacy predict is not called with device it always switches to cuda use. This change is to reuse the device set on the model.