### PR TITLE
fix: eval empty token_spans properly

### DIFF
--- a/demo/inference_on_a_image.py
+++ b/demo/inference_on_a_image.py
@@ -199,7 +199,7 @@ if __name__ == "__main__":
 
     # run model
     boxes_filt, pred_phrases = get_grounding_output(
-        model, image, text_prompt, box_threshold, text_threshold, cpu_only=args.cpu_only, token_spans=eval(token_spans)
+        model, image, text_prompt, box_threshold, text_threshold, cpu_only=args.cpu_only, token_spans=eval(f"{token_spans}")
     )
 
     # visualize pred


### PR DESCRIPTION
eval accepts only string.
When token_spans is None, it should be converted to string as well.
(Otherwise, the following error occurs.)
```
TypeError: eval() arg 1 must be a string, bytes or code object
```