### PR TITLE
[fix] replace ema_model with model in demo/test_ap_on_coco

### DIFF
--- a/demo/test_ap_on_coco.py
+++ b/demo/test_ap_on_coco.py
@@ -26,7 +26,7 @@ def load_model(model_config_path: str, model_checkpoint_path: str, device: str =
     args.device = device
     model = build_model(args)
     checkpoint = torch.load(model_checkpoint_path, map_location="cpu")
-    model.load_state_dict(clean_state_dict(checkpoint["ema_model"]), strict=False)
+    model.load_state_dict(clean_state_dict(checkpoint["model"]), strict=False)
     model.eval()
     return model
 


### PR DESCRIPTION
The checkpoint in README doesn't have key `ema_model`. Replacing `ema_model ` with `model` can reproduce the expected mAP.