### PR TITLE
specify the version for gradio for gradio_app.py

### DIFF
--- a/demo/gradio_app.py
+++ b/demo/gradio_app.py
@@ -16,7 +16,7 @@ import torch
 # prepare the environment
 os.system("python setup.py build develop --user")
 os.system("pip install packaging==21.3")
-os.system("pip install gradio")
+os.system("pip install gradio==3.50.2")
 
 
 warnings.filterwarnings("ignore")


### PR DESCRIPTION
the version 3.x and 4.x use the different api (Image)

`pip install gradio` will install the `latest gradio`

> also  found that the #295 is for gradio 4.x api.