### PR TITLE
fix Supervision depreciation of BoxAnnotator

### DIFF
--- a/groundingdino/util/inference.py
+++ b/groundingdino/util/inference.py
@@ -121,9 +121,11 @@ def annotate(image_source: np.ndarray, boxes: torch.Tensor, logits: torch.Tensor
         in zip(phrases, logits)
     ]
 
-    box_annotator = sv.BoxAnnotator()
+    bbox_annotator = sv.BoundingBoxAnnotator(color_lookup=sv.ColorLookup.INDEX)
+    label_annotator = sv.LabelAnnotator(color_lookup=sv.ColorLookup.INDEX)
     annotated_frame = cv2.cvtColor(image_source, cv2.COLOR_RGB2BGR)
-    annotated_frame = box_annotator.annotate(scene=annotated_frame, detections=detections, labels=labels)
+    annotated_frame = bbox_annotator.annotate(scene=annotated_frame, detections=detections)
+    annotated_frame = label_annotator.annotate(scene=annotated_frame, detections=detections, labels=labels)
     return annotated_frame
 
 

--- a/groundingdino/util/inference.py
+++ b/groundingdino/util/inference.py
@@ -121,7 +121,7 @@ def annotate(image_source: np.ndarray, boxes: torch.Tensor, logits: torch.Tensor
         in zip(phrases, logits)
     ]
 
-    bbox_annotator = sv.BoundingBoxAnnotator(color_lookup=sv.ColorLookup.INDEX)
+    bbox_annotator = sv.BoxAnnotator(color_lookup=sv.ColorLookup.INDEX)
     label_annotator = sv.LabelAnnotator(color_lookup=sv.ColorLookup.INDEX)
     annotated_frame = cv2.cvtColor(image_source, cv2.COLOR_RGB2BGR)
     annotated_frame = bbox_annotator.annotate(scene=annotated_frame, detections=detections)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ yapf
 timm
 numpy
 opencv-python
-supervision
+supervision>=0.15.0
 pycocotools

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ yapf
 timm
 numpy
 opencv-python
-supervision>=0.15.0
+supervision>=0.22.0
 pycocotools


### PR DESCRIPTION
Saw a warning when calling `annotate`:
```SupervisionWarnings: annotate is deprecated: BoxAnnotator is deprecated and will be removed in supervision-0.22.0. Use BoundingBoxAnnotator and LabelAnnotator instead```

Fixed by removing `BoxAnnotator` and use `BoundingBoxAnnotator` and `LabelAnnotator` as instructed by the warning.
And based on `supervision` [release note](https://supervision.roboflow.com/latest/changelog/#0150-october-5-2023), `BoundingBoxAnnotator` is added in version `0.15.0` .

Please review. Thank you!