### PR TITLE
fixed model_config_path in docker_test.py

### DIFF
--- a/docker_test.py
+++ b/docker_test.py
@@ -2,7 +2,7 @@ from groundingdino.util.inference import load_model, load_image, predict, annota
 import torch
 import cv2
 
-model = load_model("groundingdino/config/GroundingDINO_SwinT_OGC.pyy", "weights/groundingdino_swint_ogc.pth")
+model = load_model("groundingdino/config/GroundingDINO_SwinT_OGC.py", "weights/groundingdino_swint_ogc.pth")
 model = model.to('cuda:0')
 print(torch.cuda.is_available())
 print('DONE!')


### PR DESCRIPTION
Changed model_config_path string from groundingdino/config/GroundingDINO_SwinT_OGC.pyy to groundingdino/config/GroundingDINO_SwinT_OGC.py to avoid FileNotFoundError