### PR TITLE
Kabirk/fix numpy version

### DIFF
--- a/groundingdino/util/get_tokenlizer.py
+++ b/groundingdino/util/get_tokenlizer.py
@@ -23,7 +23,7 @@ def get_tokenlizer(text_encoder_type):
 def get_pretrained_language_model(text_encoder_type, model_path=None):
     if text_encoder_type == "bert-base-uncased" or (os.path.isdir(text_encoder_type) and os.path.exists(text_encoder_type)):
         # return BertModel.from_pretrained(text_encoder_type)
-        bert_model_path = os.path.join(os.getcwd(), 'src/models/bert-base-uncased')
+        bert_model_path = os.path.join(os.getcwd(), 'src/hemobox-supercharged/models/bert-base-uncased')
         tokenizer = BertTokenizer.from_pretrained(bert_model_path, do_lower_case=True, local_files_only=True)
         # model = BertModel.from_pretrained(bert_model_path)
         print(f'Loading model from {bert_model_path}')

--- a/groundingdino/util/get_tokenlizer.py
+++ b/groundingdino/util/get_tokenlizer.py
@@ -20,9 +20,15 @@ def get_tokenlizer(text_encoder_type):
     return tokenizer
 
 
-def get_pretrained_language_model(text_encoder_type):
+def get_pretrained_language_model(text_encoder_type, model_path=None):
     if text_encoder_type == "bert-base-uncased" or (os.path.isdir(text_encoder_type) and os.path.exists(text_encoder_type)):
-        return BertModel.from_pretrained(text_encoder_type)
+        # return BertModel.from_pretrained(text_encoder_type)
+        bert_model_path = os.path.join(os.getcwd(), 'src/models/bert-base-uncased')
+        tokenizer = BertTokenizer.from_pretrained(bert_model_path, do_lower_case=True, local_files_only=True)
+        # model = BertModel.from_pretrained(bert_model_path)
+        print(f'Loading model from {bert_model_path}')
+        return BertModel.from_pretrained(bert_model_path)
+
     if text_encoder_type == "roberta-base":
         return RobertaModel.from_pretrained(text_encoder_type)
 

--- a/groundingdino/util/get_tokenlizer.py
+++ b/groundingdino/util/get_tokenlizer.py
@@ -33,3 +33,4 @@ def get_pretrained_language_model(text_encoder_type, model_path=None):
         return RobertaModel.from_pretrained(text_encoder_type)
 
     raise ValueError("Unknown text_encoder_type {}".format(text_encoder_type))
+    # now it should load offline

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
-torch
-torchvision
+#torch
+#torchvision
 transformers
 addict
 yapf
 timm
 numpy
-opencv-python
+#opencv-python
 supervision>=0.22.0
 pycocotools
+
+#commented deps are already present in the robot env (docker image)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ transformers
 addict
 yapf
 timm
-numpy
+numpy==1.26.4
 #opencv-python
 supervision>=0.22.0
 pycocotools


### PR DESCRIPTION
Fixes Numpy Version. 
Needed because grounding dino upgrades numpy to 2.2.6 which breaks pytorch