### PR TITLE
Fix typo in docker_test.py

### DIFF
--- a/docker_test.py
+++ b/docker_test.py
@@ -2,7 +2,7 @@ from groundingdino.util.inference import load_model, load_image, predict, annota
 import torch
 import cv2
 
-model = load_model("groundingdino/config/GroundingDINO_SwinT_OGC.pyy", "weights/groundingdino_swint_ogc.pth")
+model = load_model("groundingdino/config/GroundingDINO_SwinT_OGC.py", "weights/groundingdino_swint_ogc.pth")
 model = model.to('cuda:0')
 print(torch.cuda.is_available())
 print('DONE!')


### PR DESCRIPTION
This pull request corrects a minor typo in the model configuration filename within docker_test.py.

Fixed `GroundingDINO_SwinT_OGC.pyy` → `GroundingDINO_SwinT_OGC.py`.
This resolves a FileNotFoundError during model loading caused by the extra “`y`”.