### PR TITLE
fix: update BoxAnnotator API for supervision >=0.16 (code + docs)

### DIFF
--- a/groundingdino/util/inference.py
+++ b/groundingdino/util/inference.py
@@ -172,7 +172,9 @@ class Model:
         import supervision as sv
 
         box_annotator = sv.BoxAnnotator()
-        annotated_image = box_annotator.annotate(scene=image, detections=detections, labels=labels)
+        label_annotator = sv.LabelAnnotator()
+        annotated_image = box_annotator.annotate(scene=image, detections=detections)
+        annotated_image = label_annotator.annotate(scene=annotated_image, detections=detections, labels=labels)
         """
         processed_image = Model.preprocess_image(image_bgr=image).to(self.device)
         boxes, logits, phrases = predict(


### PR DESCRIPTION
Fixes #408

PR #443 fixed the docstring examples but the actual code in inference.py still uses the deprecated API. This PR fixes both the code and any remaining docstrings.

supervision >=0.16 removed the labels parameter from BoxAnnotator.annotate(). Labels should be added via LabelAnnotator instead.