### PR TITLE
Fix load_model ignoring device parameter

### DIFF
--- a/groundingdino/util/inference.py
+++ b/groundingdino/util/inference.py
@@ -33,6 +33,7 @@ def load_model(model_config_path: str, model_checkpoint_path: str, device: str =
     checkpoint = torch.load(model_checkpoint_path, map_location="cpu")
     model.load_state_dict(clean_state_dict(checkpoint["model"]), strict=False)
     model.eval()
+    model = model.to(device)
     return model
 
 


### PR DESCRIPTION
Fixes #71

load_model accepts a device parameter but never calls model.to(device),
so the model stays on whatever device build_model puts it on. This
means users of the old API who pass device="cpu" still get a model on
CUDA (or wherever build_model defaults to), and the subsequent predict()
call will try to move everything to CUDA.

This complements the existing fix from PR #77 (which added device=self.device
to the predict() calls in the Model class) by ensuring load_model itself
actually respects the device argument.

Fix: call model = model.to(device) after loading state dict and setting
eval mode.